### PR TITLE
2.0: Fully use the HeaderBag and some cleanup

### DIFF
--- a/src/HeaderBag.php
+++ b/src/HeaderBag.php
@@ -98,7 +98,7 @@ class Header
 
     public function getName()
     {
-        return $this->name;
+        return strtolower($this->name);
     }
 
     public function is($name)
@@ -111,9 +111,19 @@ class Header
         return $this->value;
     }
 
+    public function setValue($newValue)
+    {
+        $this->value = $newValue;
+    }
+
     public function getProps()
     {
         return $this->props;
+    }
+
+    public function setProps(array $newProps)
+    {
+        $this->props = $newProps;
     }
 
     public function __toString()

--- a/src/HeaderBag.php
+++ b/src/HeaderBag.php
@@ -10,7 +10,8 @@ class HeaderBag
 
     public function __construct(array $headers = array())
     {
-        // Send all headers through `add` to make sure they are properly lower-cased
+        # Send all headers through `add` to make sure they are properly
+        # lower-cased
         foreach ($headers as $name => $value)
         {
             $this->add($name, $value);

--- a/src/HeaderBag.php
+++ b/src/HeaderBag.php
@@ -41,21 +41,21 @@ class HeaderBag
         return array_key_exists(strtolower($name), $this->headers);
     }
 
-    public function add($name, $value = '')
+    public function add($name, $value = '', $props = array())
     {
         Types::assert(array('string' => array($name, $value)));
 
         $key = strtolower($name);
         if ( ! array_key_exists($key, $this->headers)) $this->headers[$key] = array();
 
-        $this->headers[$key][] = new Header($name, $value);
+        $this->headers[$key][] = new Header($name, $value, $props);
     }
 
-    public function replace($name, $value = '')
+    public function replace($name, $value = '', $props = array())
     {
         Types::assert(array('string' => array($name, $value)));
 
-        $header = new Header($name, $value);
+        $header = new Header($name, $value, $props);
         $this->headers[strtolower($name)] = array($header);
     }
 
@@ -87,11 +87,13 @@ class Header
 {
     private $name;
     private $value;
+    private $props;
 
-    public function __construct($name, $value = '')
+    public function __construct($name, $value = '', array $props = array())
     {
         $this->name = $name;
         $this->value = $value;
+        $this->props = $props;
     }
 
     public function getName()
@@ -99,9 +101,19 @@ class Header
         return $this->name;
     }
 
+    public function is($name)
+    {
+        return strtolower($name) === strtolower($this->name);
+    }
+
     public function getValue()
     {
         return $this->value;
+    }
+
+    public function getProps()
+    {
+        return $this->props;
     }
 
     public function __toString()

--- a/src/Http/GlobalHttpAdapter.php
+++ b/src/Http/GlobalHttpAdapter.php
@@ -19,7 +19,8 @@ class GlobalHttpAdapter implements HttpAdapter
         foreach ($headers->get() as $header)
         {
             header(
-                (string) $header
+                (string) $header,
+                false
             );
         }
     }

--- a/src/Http/StringHttpAdapter.php
+++ b/src/Http/StringHttpAdapter.php
@@ -7,6 +7,12 @@ use Aidantwoods\SecureHeaders\HeaderBag;
 class StringHttpAdapter implements HttpAdapter
 {
     private $headers = array();
+    private $initialHeaders;
+
+    public function __construct(array $initialHeaders = array())
+    {
+        $this->initialHeaders = $initialHeaders;
+    }
 
     /**
      * Send the given headers, overwriting all previously send headers
@@ -26,10 +32,10 @@ class StringHttpAdapter implements HttpAdapter
      */
     public function getHeaders()
     {
-        return new HeaderBag();
+        return HeaderBag::fromHeaderLines($this->initialHeaders);
     }
 
-    public function getHeadersAsString()
+    public function getSentHeaders()
     {
         $compiledHeaders = array();
 

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -459,10 +459,8 @@ class SecureHeaders{
         }
     }
 
-    public function header(
-        $name,
-        $value = null
-    ) {
+    public function header($name, $value = null)
+    {
         Types::assert(array('string' => array($name, $value)));
 
         $this->addHeader($name, $value);
@@ -1770,10 +1768,8 @@ class SecureHeaders{
 
             $changed = false;
 
-            foreach (
-                $this->safeModeUnsafeHeaders[$headerName]
-                as $attribute => $default
-            ) {
+            foreach ($this->safeModeUnsafeHeaders[$headerName] as $attribute => $default)
+            {
                 # if the attribute is also set
                 if (isset($data['attributes'][$attribute]))
                 {
@@ -2058,9 +2054,8 @@ class SecureHeaders{
             === self::AUTO_COOKIE_SECURE
         ) {
             # add a secure flag to cookies that look like they hold session data
-            foreach (
-                $this->protectedCookies['substrings'] as $substr
-            ) {
+            foreach ($this->protectedCookies['substrings'] as $substr)
+            {
                 $this->modifyCookie($substr, 'secure');
             }
 
@@ -2076,9 +2071,8 @@ class SecureHeaders{
         ) {
             # add a httpOnly flag to cookies that look like they hold
             # session data
-            foreach (
-                $this->protectedCookies['substrings'] as $substr
-            ) {
+            foreach ($this->protectedCookies['substrings'] as $substr)
+            {
                 $this->modifyCookie($substr, 'httpOnly');
             }
 

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -945,9 +945,6 @@ class SecureHeaders{
             $this->addHeader($header->getName(), $header->getValue());
         }
 
-        # delete them (we'll set them again later)
-        $this->headers->removeAll();
-
         $this->allowImports = false;
     }
 

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -938,9 +938,9 @@ class SecureHeaders{
         $this->importStarted = true;
         # grab any headers that were already set and, if any,
         # add these to our internal header list
-        $this->headers = $this->httpAdapter->getHeaders();
+        $importedHeaders = $this->httpAdapter->getHeaders();
 
-        foreach ($this->headers->get() as $header)
+        foreach ($importedHeaders->get() as $header)
         {
             $this->addHeader($header->getName(), $header->getValue());
         }

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -1113,7 +1113,7 @@ class SecureHeaders{
             $this->headers->add('Set-Cookie', $headerString);
         }
 
-        // And finally, send all headers through whatever adapter we are using
+        # And finally, send all headers through whatever adapter we are using
         $this->httpAdapter->sendHeaders($this->headers);
     }
 

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -281,14 +281,7 @@ class SecureHeaders{
 
     public function safeMode($mode = true)
     {
-        if ($mode == false or strtolower($mode) === 'off')
-        {
-            $this->safeMode = false;
-        }
-        else
-        {
-            $this->safeMode = true;
-        }
+        $this->safeMode = ($mode == true and strtolower($mode) !== 'off');
     }
 
     # if operating in safe mode, use this to manually allow a specific header
@@ -302,14 +295,7 @@ class SecureHeaders{
 
     public function strictMode($mode = true)
     {
-        if ($mode == false or strtolower($mode) === 'off')
-        {
-            $this->strictMode = false;
-        }
-        else
-        {
-            $this->strictMode = true;
-        }
+        $this->strictMode = ($mode == true and strtolower($mode) !== 'off');
     }
 
     public function returnExistingNonce($mode = true)

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -372,9 +372,11 @@ class SecureHeaders{
     # ~~
     # public functions: raw headers
 
-    public function addHeader($name, $value = null)
+    public function addHeader($name, $value = null, $replace = null)
     {
         Types::assert(array('string' => array($name, $value)));
+
+        if ( ! isset($replace)) $replace = true;
 
         if (
             $this->correctHeaderName
@@ -442,7 +444,7 @@ class SecureHeaders{
         # add the header, and disect its value
         else
         {
-            $this->headers->replace(
+            $this->headers->{$replace ? 'replace' : 'add'}(
                 $capitalisedName,
                 $value,
                 array(
@@ -460,11 +462,11 @@ class SecureHeaders{
         }
     }
 
-    public function header($name, $value = null)
+    public function header($name, $value = null, $replace = null)
     {
         Types::assert(array('string' => array($name, $value)));
 
-        $this->addHeader($name, $value);
+        $this->addHeader($name, $value, $replace);
     }
 
     public function removeHeader($name)
@@ -943,7 +945,7 @@ class SecureHeaders{
 
         foreach ($importedHeaders->get() as $header)
         {
-            $this->addHeader($header->getName(), $header->getValue());
+            $this->addHeader($header->getName(), $header->getValue(), false);
         }
 
         $this->allowImports = false;

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -52,21 +52,21 @@ class SecureHeaders{
     # ~~
     # protected variables: settings
 
-    protected $errorReporting = true;
+    protected $errorReporting       = true;
 
-    protected $cspLegacy = false;
-    protected $returnExistingNonce = true;
+    protected $cspLegacy            = false;
+    protected $returnExistingNonce  = true;
 
-    protected $strictMode = false;
+    protected $strictMode           = false;
 
-    protected $safeMode = false;
-    protected $safeModeExceptions = array();
+    protected $safeMode             = false;
+    protected $safeModeExceptions   = array();
 
-    protected $automaticHeaders = self::AUTO_ALL;
+    protected $automaticHeaders     = self::AUTO_ALL;
 
-    protected $correctHeaderName = true;
+    protected $correctHeaderName    = true;
 
-    protected $protectedCookies = array(
+    protected $protectedCookies     = array(
         'substrings' => array(
             'sess',
             'auth',
@@ -98,7 +98,7 @@ class SecureHeaders{
     private $csp                = array();
     private $cspro              = array();
 
-    private $cspNonces         = array(
+    private $cspNonces          = array(
         'enforced'      =>  array(),
         'reportOnly'    =>  array()
     );
@@ -108,8 +108,9 @@ class SecureHeaders{
     private $hpkp               = array();
     private $hpkpro             = array();
 
-    private $importStarted      = false;
     private $allowImports       = true;
+    private $importStarted      = false;
+
     private $proposeHeaders     = false;
 
     private $isBufferReturned   = false;
@@ -118,7 +119,7 @@ class SecureHeaders{
 
     # private variables: (pre-defined static structures)
 
-    private $cspDirectiveShortcuts = array(
+    private $cspDirectiveShortcuts  = array(
         'default'           =>  'default-src',
         'script'            =>  'script-src',
         'style'             =>  'style-src',
@@ -134,7 +135,7 @@ class SecureHeaders{
         'reporting'         =>  'report-uri'
     );
 
-    private $cspSourceShortcuts = array(
+    private $cspSourceShortcuts     = array(
         'self'              =>  "'self'",
         'none'              =>  "'none'",
         'unsafe-inline'     =>  "'unsafe-inline'",
@@ -149,22 +150,22 @@ class SecureHeaders{
         'object-src'
     );
 
-    protected $csproBlacklist = array(
+    protected $csproBlacklist       = array(
         'block-all-mixed-content',
         'upgrade-insecure-requests'
     );
 
-    private $allowedCSPHashAlgs = array(
+    private $allowedCSPHashAlgs     = array(
         'sha256',
         'sha384',
         'sha512'
     );
 
-    private $allowedHPKPAlgs = array(
+    private $allowedHPKPAlgs        = array(
         'sha256'
     );
 
-    private $safeModeUnsafeHeaders = array(
+    private $safeModeUnsafeHeaders  = array(
         'strict-transport-security' => array(
             'max-age' => 86400,
             'includesubdomains' => false,
@@ -188,7 +189,7 @@ class SecureHeaders{
         )
     );
 
-    private $reportMissingHeaders = array(
+    private $reportMissingHeaders   = array(
         'Strict-Transport-Security',
         'Content-Security-Policy',
         'X-XSS-Protection',
@@ -223,24 +224,24 @@ class SecureHeaders{
             # assert that match covers the entire value
             (?=[ ;]|$)/ix';
 
-        # ~
-        # Constants
+    # ~
+    # Constants
 
-        # auto-headers
+    # auto-headers
 
-        const AUTO_ADD              =  1; # 0b0001
-        const AUTO_REMOVE           =  2; # 0b0010
-        const AUTO_COOKIE_SECURE    =  4; # 0b0100
-        const AUTO_COOKIE_HTTPONLY  =  8; # 0b1000
-        const AUTO_ALL              = 15; # 0b1111
+    const AUTO_ADD              =  1; # 0b0001
+    const AUTO_REMOVE           =  2; # 0b0010
+    const AUTO_COOKIE_SECURE    =  4; # 0b0100
+    const AUTO_COOKIE_HTTPONLY  =  8; # 0b1000
+    const AUTO_ALL              = 15; # 0b1111
 
-        # cookie upgrades
+    # cookie upgrades
 
-        const COOKIE_NAME           =  1; # 0b0001
-        const COOKIE_SUBSTR         =  2; # 0b0010
-        const COOKIE_ALL            =  3; # COOKIE_NAME | COOKIE_SUBSTR
-        const COOKIE_REMOVE         =  4; # 0b0100
-        const COOKIE_DEFAULT        =  2; # ~COOKIE_REMOVE & COOKIE_SUBSTR
+    const COOKIE_NAME           =  1; # 0b0001
+    const COOKIE_SUBSTR         =  2; # 0b0010
+    const COOKIE_ALL            =  3; # COOKIE_NAME | COOKIE_SUBSTR
+    const COOKIE_REMOVE         =  4; # 0b0100
+    const COOKIE_DEFAULT        =  2; # ~COOKIE_REMOVE & COOKIE_SUBSTR
 
     # ~~
     # Public Functions
@@ -371,10 +372,8 @@ class SecureHeaders{
     # ~~
     # public functions: raw headers
 
-    public function addHeader(
-        $name,
-        $value = null
-    ) {
+    public function addHeader($name, $value = null)
+    {
         Types::assert(array('string' => array($name, $value)));
 
         if (
@@ -447,8 +446,10 @@ class SecureHeaders{
                 $capitalisedName,
                 $value,
                 array(
-                    'attributes' => $this->deconstructHeaderValue($value, $name),
-                    'attributePositions' => $this->deconstructHeaderValue($value, $name, true)
+                    'attributes' =>
+                        $this->deconstructHeaderValue($value, $name),
+                    'attributePositions' =>
+                        $this->deconstructHeaderValue($value, $name, true)
                 )
             );
         }
@@ -1815,7 +1816,7 @@ class SecureHeaders{
 
     private function isFineInSafeMode($headerName)
     {
-        return !isset($this->safeModeUnsafeHeaders[$headerName]) or !empty($this->safeModeExceptions[$headerName]);
+        return ! isset($this->safeModeUnsafeHeaders[$headerName]) or ! empty($this->safeModeExceptions[$headerName]);
     }
 
     private function modifyHeaderValue(Header $header, $attribute, $newValue)
@@ -1891,9 +1892,8 @@ class SecureHeaders{
         # correct the positions of other attributes (replace may have varied
         # length of string)
 
-        foreach (
-            $props['attributePositions'] as $i => $position
-        ) {
+        foreach ($props['attributePositions'] as $i => $position)
+        {
             if ( ! is_int($position)) continue;
 
             if ($position > $currentOffset)

--- a/tests/HeaderBagTest.php
+++ b/tests/HeaderBagTest.php
@@ -16,6 +16,16 @@ class HeaderBagTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($headers->has('Content-Type'));
         $this->assertTrue($headers->has('Content-Length'));
+
+        $export = array_map(function ($header) { return (string) $header; }, $headers->get());
+
+        $this->assertEquals(
+            array(
+                'Content-Type: text/html',
+                'Content-Length: 123',
+            ),
+            $export
+        );
     }
 
     public function testInstantiationFromHeaderLines()
@@ -27,6 +37,16 @@ class HeaderBagTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($headers->has('Content-Type'));
         $this->assertTrue($headers->has('Content-Length'));
+
+        $export = array_map(function ($header) { return (string) $header; }, $headers->get());
+
+        $this->assertEquals(
+            array(
+                'Content-Type: text/html',
+                'Content-Length: 123',
+            ),
+            $export
+        );
     }
 
     public function testCaseIsPreserved()

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -31,6 +31,22 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
         $this->assertContains('X-Foo: Bar', $headersString);
     }
 
+    public function testRegularHeaderNotLost()
+    {
+        $headerStrings = new StringHttpAdapter;
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+
+        $headers->addHeader('X-Foo', 'Bar');
+
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertContains('X-Foo: Bar', $headersString);
+    }
+
     public function testThreeDefaultHeadersAreAdded()
     {
         $headerStrings = new StringHttpAdapter;

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -16,6 +16,21 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
         'NotRegExp'
     );
 
+    public function testExistingHeadersAreSent()
+    {
+        $headerStrings = new StringHttpAdapter(array(
+            'X-Foo: Bar',
+        ));
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertContains('X-Foo: Bar', $headersString);
+    }
+
     function dataSafeMode()
     {
         return array(
@@ -92,7 +107,7 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
         $test($headers);
         $headers->done();
 
-        $headersString = $headerStrings->getHeadersAsString();
+        $headersString = $headerStrings->getSentHeaders();
 
         foreach ($this->assertions as $assertion)
         {
@@ -111,7 +126,7 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
                 }
             }
         }
-      }
+    }
 
 
     function dataStrictMode()
@@ -226,7 +241,7 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
         $test($headers);
         $headers->done();
 
-        $headersString = $headerStrings->getHeadersAsString();
+        $headersString = $headerStrings->getSentHeaders();
 
         foreach ($this->assertions as $assertion)
         {

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -31,6 +31,55 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
         $this->assertContains('X-Foo: Bar', $headersString);
     }
 
+    public function testThreeDefaultHeadersAreAdded()
+    {
+        $headerStrings = new StringHttpAdapter;
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertContains('X-XSS-Protection: 1; mode=block', $headersString);
+        $this->assertContains('X-Content-Type-Options: nosniff', $headersString);
+        $this->assertContains('X-Frame-Options: Deny', $headersString);
+    }
+
+    public function testDefaultHeadersDoNotReplaceExistingHeaders()
+    {
+        $headerStrings = new StringHttpAdapter(array(
+            'X-Frame-Options: sameorigin',
+        ));
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertContains('X-XSS-Protection: 1; mode=block', $headersString);
+        $this->assertContains('X-Content-Type-Options: nosniff', $headersString);
+        $this->assertContains('X-Frame-Options: sameorigin', $headersString);
+        $this->assertNotContains('X-Frame-Options: Deny', $headersString);
+    }
+
+    public function testDefaultHeadersCanBeExplicitlyRemoved()
+    {
+        $headerStrings = new StringHttpAdapter;
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+        $headers->removeHeader('X-XSS-Protection');
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertContains('X-Content-Type-Options: nosniff', $headersString);
+        $this->assertContains('X-Frame-Options: Deny', $headersString);
+        $this->assertNotContains('X-XSS-Protection', $headersString);
+    }
+
     function dataSafeMode()
     {
         return array(

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -47,6 +47,65 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
         $this->assertContains('X-Foo: Bar', $headersString);
     }
 
+    public function testCookies()
+    {
+        $headerStrings = new StringHttpAdapter(array(
+            'Set-Cookie: normalcookie=value1',
+            'Set-Cookie: authcookie=value2',
+        ));
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertContains('Set-Cookie: normalcookie=value1', $headersString);
+        $this->assertContains('Set-Cookie: authcookie=value2; Secure; HttpOnly', $headersString);
+    }
+
+    public function testMultipleHeaders()
+    {
+        $headerStrings = new StringHttpAdapter(array(
+            'X-Bar: Foo1',
+            'X-Bar: Foo2',
+        ));
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+
+        $headers->addHeader('X-Foo', 'Bar1', false);
+        $headers->addHeader('X-Foo', 'Bar2', false);
+
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertContains('X-Foo: Bar1', $headersString);
+        $this->assertContains('X-Foo: Bar2', $headersString);
+        $this->assertContains('X-Bar: Foo1', $headersString);
+        $this->assertContains('X-Bar: Foo2', $headersString);
+    }
+
+    public function testHeadersAreReplaced()
+    {
+        $headerStrings = new StringHttpAdapter;
+
+        $headers = new SecureHeaders($headerStrings);
+        $headers->errorReporting(false);
+
+        $headers->addHeader('X-Foo', 'Bar1');
+        $headers->addHeader('X-Foo', 'Bar2');
+
+        $headers->done();
+
+        $headersString = $headerStrings->getSentHeaders();
+
+        $this->assertNotContains('X-Foo: Bar1', $headersString);
+        $this->assertContains('X-Foo: Bar2', $headersString);
+    }
+
     public function testThreeDefaultHeadersAreAdded()
     {
         $headerStrings = new StringHttpAdapter;


### PR DESCRIPTION
Hi, welcome to the next round. :smile: 

As promised, I worked on replacing the `$headers` array with the `HeaderBag` instance. This was mostly lacking the extra properties that you saved with each header - this is now all stored in the `Header` instances within the `HeaderBag`.

I also did some smaller refactorings (shorten methods, flatten code). I hope I kept the style changes to a minimum, although I would really advise going for a well-specified standard like PSR-2.