### PR TITLE
Ensure StyleCI also uses short array syntax.

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,6 @@
 preset: psr2
 
 enabled:
-  - long_array_syntax
+  - short_array_syntax
 
 linting: true


### PR DESCRIPTION
Ensure StyleCI also uses short array syntax.