### PR TITLE
Feature/expect ct

### DIFF
--- a/docs/v2/expectCT.md
+++ b/docs/v2/expectCT.md
@@ -1,0 +1,35 @@
+## Description
+```php
+void expectCT (
+    [ ?int | string $maxAge = 31536000 
+    [, ?mixed $enforce = true 
+    [, ?string $reportUri = null ] ] ] 
+)
+```
+
+Used to add and configure the Expect-CT header.
+Expect-CT makes sure that a user's browser will fill the role of
+ensuring that future requests, within $maxAge seconds will have
+certificate transparancy.
+
+If set to enforcement mode, the browser will fail the TLS connection if
+the certificate transparency requirement is not met
+
+## Parameters
+### maxAge
+The length, in seconds either as a string, or an integer – specify the
+ length that a user's browser should remember that the application
+ should be delivered with a certificate transparency expectation.
+
+### enforce
+Loosely casted as a boolean, whether to enforce (by failing the TLS
+ connection) that certificate transparency is enabled for the next
+ $maxAge seconds, or whether to only report to the console, and to
+ $reportUri if an address is defined.
+
+### reportUri
+A reporting address to send violation reports to.
+
+ Passing `null` indicates that a reporting address should not be modified
+ on this call (e.g. can be used to prevent overwriting a previous
+ setting).

--- a/docs/v2/strictMode.md
+++ b/docs/v2/strictMode.md
@@ -1,23 +1,43 @@
 ## Description
 ```php
-void strictMode ( [ mixed $mode = true ] )
+void strictMode ([ mixed $mode = true ] )
 ```
 
-`->strictMode()` will turn strict mode on or off.
+Turn strict mode on or off.
+When enabled, strict mode will:
+* Auto-enable HSTS with a 1 year duration, and the `includeSubDomains`
+  and `preload` flags set. Note that this HSTS policy is made as a
+  [header proposal](header-proposals), and can thus be removed or
+  modified.
 
-* When enabled, strict mode will auto-enable HSTS with a 1 year duration, and the `includeSubDomains` and `preload` flags set. Note that this HSTS policy is made as a [header proposal](header-proposals), and can thus be removed or modified.
+* The source keyword `'strict-dynamic'` will also be added to the first
+  of the following directives that exist: `script-src`, `default-src`;
+  only if that directive also contains a nonce or hash source value, and
+  not otherwise.
 
-* The source keyword `'strict-dynamic'` will also be added to the first of the following directives that exist: `script-src`, `default-src`; only if that directive also contains a nonce or hash source value, and not otherwise.
+  This will disable the source whitelist in `script-src` in CSP3
+  compliant browsers. The use of whitelists in script-src is
+  [considered not to be an ideal practice][1], because they are often
+  trivial to bypass.
 
-  This will disable the source whitelist in `script-src` in CSP3 compliant browsers. The use of whitelists in script-src is [considered not to be an ideal practice][1], because they are often trivial to bypass.
+  [1]: https://research.google.com/pubs/pub45542.html "The Insecurity of
+  Whitelists and the Future of Content Security Policy"
 
-  [1]: https://research.google.com/pubs/pub45542.html "The Insecurity of Whitelists and the Future of Content Security Policy"
+  Don't forget to [manually submit](https://hstspreload.appspot.com/)
+  your domain to the HSTS preload list if you are using this option.
 
-  Don't forget to [manually submit](https://hstspreload.appspot.com/) your domain to the HSTS preload list if you are using this option.
+* The default `SameSite` value injected into [`->protectedCookie`](protectedCookie) will
+  be changed from `SameSite=Lax` to `SameSite=Strict`.
+  See [`->auto`](auto#AUTO_COOKIE_SAMESITE) to enable/disable injection
+  of `SameSite` and [`->sameSiteCookies`](sameSiteCookies) for more on specific behaviour
+  and to explicitly define this value manually, to override the default.
 
-* The default `SameSite` value injected into [protected cookies](protectedCookie) will be changed from `SameSite=Lax` to `SameSite=Strict`. See [`->auto`](auto#AUTO_COOKIE_SAMESITE) to enable/disable injection of `SameSite` and [`->sameSiteCookies`](sameSiteCookies) for more on specific behaviour and to explicitly define this value manually, to override the default.
-
+* Auto-enable Expect-CT with a 1 year duration, and the `enforce` flag
+  set. Note that this Expect-CT policy is made as a
+  [header proposal](header-proposals), and can thus be removed or
+  modified.
 
 ## Parameters
 ### mode
-Loosely casted to a boolean, `true` enables strict mode, `false` turns it off.
+Loosely casted to a boolean, `true` enables strict mode, `false` turns
+ it off.

--- a/src/Operations/ApplySafeMode.php
+++ b/src/Operations/ApplySafeMode.php
@@ -12,6 +12,7 @@ class ApplySafeMode extends OperationWithErrors implements Operation, ExposesErr
     private static $unsafeHeaders = [
         'strict-transport-security' => 'sanitizeSTS',
         'public-key-pins' => 'sanitizePKP',
+        'expect-ct' => 'sanitizeExpectCT',
     ];
 
     private $exceptions;
@@ -81,6 +82,21 @@ class ApplySafeMode extends OperationWithErrors implements Operation, ExposesErr
         {
             $this->addError(
                 'Some HPKP settings were overridden because Safe-Mode is enabled.'
+            );
+        }
+    }
+
+    private function sanitizeExpectCT(Header $header)
+    {
+        $origValue = $header->getValue();
+
+        # Only do these when the attributes exist
+        $header->removeAttribute('enforce');
+
+        if ($header->getValue() !== $origValue)
+        {
+            $this->addError(
+                'Some ExpectCT settings were overridden because Safe-Mode is enabled.'
             );
         }
     }

--- a/src/Operations/CompileExpectCT.php
+++ b/src/Operations/CompileExpectCT.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Aidantwoods\SecureHeaders\Operations;
+
+use Aidantwoods\SecureHeaders\HeaderBag;
+use Aidantwoods\SecureHeaders\Operation;
+
+class CompileExpectCT implements Operation
+{
+    private $config;
+
+    public function __construct(array $expectCTConfig)
+    {
+        $this->config = $expectCTConfig;
+    }
+
+    /**
+     * Transform the given set of headers
+     *
+     * @param HeaderBag $headers
+     * @return void
+     */
+    public function modify(HeaderBag &$headers)
+    {
+        $headers->replace(
+            'Expect-CT',
+            $this->makeHeaderValue()
+        );
+    }
+
+    private function makeHeaderValue()
+    {
+        $pieces = ['max-age=' . (int) $this->config['max-age']];
+
+        if ($this->config['enforce'])
+        {
+            $pieces[] = 'enforce';
+        }
+
+        if ($this->config['report-uri'])
+        {
+            $pieces[] = 'report-uri="' . $this->config['report-uri'] . '"';
+        }
+
+        return implode('; ', $pieces);
+    }
+}

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -304,10 +304,11 @@ class SecureHeaders
     /**
      * Turn strict mode on or off.
      *
-     * * When enabled, strict mode will auto-enable HSTS with a 1 year duration,
-     *   and the `includeSubDomains` and `preload` flags set. Note that this
-     *   HSTS policy is made as a [header proposal](header-proposals), and can
-     *   thus be removed or modified.
+     * When enabled, strict mode will:
+     * * Auto-enable HSTS with a 1 year duration, and the `includeSubDomains`
+     *   and `preload` flags set. Note that this HSTS policy is made as a
+     *   [header proposal](header-proposals), and can thus be removed or
+     *   modified.
      *
      * * The source keyword `'strict-dynamic'` will also be added to the first
      *   of the following directives that exist: `script-src`, `default-src`;
@@ -330,6 +331,11 @@ class SecureHeaders
      *   See [`->auto`](auto#AUTO_COOKIE_SAMESITE) to enable/disable injection
      *   of `SameSite` and {@see sameSiteCookies} for more on specific behaviour
      *   and to explicitly define this value manually, to override the default.
+     *
+     * * Auto-enable Expect-CT with a 1 year duration, and the `enforce` flag
+     *   set. Note that this Expect-CT policy is made as a
+     *   [header proposal](header-proposals), and can thus be removed or
+     *   modified.
      *
      * @param mixed $mode
      *  Loosely casted to a boolean, `true` enables strict mode, `false` turns

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -180,6 +180,7 @@ class SecureHeaders
     ];
 
     private $reportMissingHeaders   = [
+        'Expect-CT',
         'Strict-Transport-Security',
         'Content-Security-Policy',
         'X-Permitted-Cross-Domain-Policies',

--- a/tests/Operations/ApplySafeModeTest.php
+++ b/tests/Operations/ApplySafeModeTest.php
@@ -45,4 +45,25 @@ class ApplySafeModeTest extends PHPUnit_Framework_TestCase
             $allHeaders[0]->getValue()
         );
     }
+
+    public function testEnforcedExpectCTWillBecomeNonEnforced()
+    {
+        $headers = HeaderBag::fromHeaderLines([
+            'Expect-CT: max-age=31536000; enforce',
+            'Expect-CT: max-age=31536000; Enforce',
+            'Expect-CT: max-age=31536000; ENFORCE',
+            'Expect-CT: eNFORcE; max-age=31536000',
+        ]);
+
+        $operation = new ApplySafeMode();
+        $operation->modify($headers);
+
+        foreach ($headers->get() as $header)
+        {
+            $this->assertEquals(
+                false,
+                $header->hasAttribute('enforce')
+            );
+        }
+    }
 }

--- a/tests/SafeModeTest.php
+++ b/tests/SafeModeTest.php
@@ -71,7 +71,46 @@ class SafeModeTest extends PHPUnit_Framework_TestCase
                     'Contains' =>
                         'Public-Key-Pins: max-age=10; pin-sha256="abcd"'
                 ]
-            ]
+            ],
+            [
+                'test' =>
+                    function (&$headers)
+                    {
+                        $headers->expectCT(31536000, true, 'https://report.exampe.com');
+                    },
+                'assertions' => [
+                    'Contains' =>
+                        'Expect-CT: max-age=31536000; enforce; report-uri="https://report.exampe.com"'
+                ]
+            ],
+            [
+                'test' =>
+                    function (&$headers)
+                    {
+                        $headers->safeMode();
+                        $headers->expectCT(31536000, true, 'https://report.exampe.com');
+                    },
+                'assertions' => [
+                    'NotContains' =>
+                        'Expect-CT: max-age=31536000; enforce; report-uri="https://report.exampe.com"',
+                    'Contains' =>
+                        'Expect-CT: max-age=31536000; report-uri="https://report.exampe.com"'
+                ]
+            ],
+            [
+                'test' =>
+                    function (&$headers)
+                    {
+                        $headers->safeMode();
+                        $headers->strictMode();
+                    },
+                'assertions' => [
+                    'NotContains' =>
+                        'Expect-CT: max-age=31536000; enforce',
+                    'Contains' =>
+                        'Expect-CT: max-age=31536000',
+                ]
+            ],
         ];
     }
 

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -31,7 +31,7 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
         $this->assertContains('X-Foo: Bar', $headersString);
     }
 
-    public function testFourDefaultHeadersAreAdded()
+    public function testSevenDefaultHeadersAreAdded()
     {
         $headerStrings = new StringHttpAdapter;
 
@@ -41,6 +41,9 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
 
         $headersString = $headerStrings->getSentHeaders();
 
+        $this->assertContains('Expect-CT: max-age=0', $headersString);
+        # we want to ensure ordering here, hence two header test
+        $this->assertContains("Referrer-Policy: no-referrer\nReferrer-Policy: strict-origin-when-cross-origin", $headersString);
         $this->assertContains('X-Permitted-Cross-Domain-Policies: none', $headersString);
         $this->assertContains('X-XSS-Protection: 1; mode=block', $headersString);
         $this->assertContains('X-Content-Type-Options: nosniff', $headersString);
@@ -59,6 +62,9 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
 
         $headersString = $headerStrings->getSentHeaders();
 
+        $this->assertContains('Expect-CT: max-age=0', $headersString);
+        # we want to ensure ordering here, hence two header test
+        $this->assertContains("Referrer-Policy: no-referrer\nReferrer-Policy: strict-origin-when-cross-origin", $headersString);
         $this->assertContains('X-Permitted-Cross-Domain-Policies: none', $headersString);
         $this->assertContains('X-XSS-Protection: 1; mode=block', $headersString);
         $this->assertContains('X-Content-Type-Options: nosniff', $headersString);
@@ -77,6 +83,9 @@ class SecureHeadersTest extends PHPUnit_Framework_TestCase
 
         $headersString = $headerStrings->getSentHeaders();
 
+        $this->assertContains('Expect-CT: max-age=0', $headersString);
+        # we want to ensure ordering here, hence two header test
+        $this->assertContains("Referrer-Policy: no-referrer\nReferrer-Policy: strict-origin-when-cross-origin", $headersString);
         $this->assertContains('X-Permitted-Cross-Domain-Policies: none', $headersString);
         $this->assertContains('X-Content-Type-Options: nosniff', $headersString);
         $this->assertContains('X-Frame-Options: Deny', $headersString);

--- a/tests/StrictModeHeadersTest.php
+++ b/tests/StrictModeHeadersTest.php
@@ -35,6 +35,17 @@ class StrictModeHeadersTest extends PHPUnit_Framework_TestCase
                     function (&$headers)
                     {
                         $headers->strictMode();
+                    },
+                'assertions' => [
+                    'Contains' =>
+                        'Expect-CT: max-age=31536000; enforce'
+                ]
+            ],
+            [
+                'test' =>
+                    function (&$headers)
+                    {
+                        $headers->strictMode();
                         $headers->cspNonce('script');
                     },
                 'assertions' => [


### PR DESCRIPTION
Implement Expect-CT support from #19 

---

About:
Expect-CT is similar to HSTS, where the criteria to fail the TLS connection is lack of certificate transparency.

Draft spec here: https://datatracker.ietf.org/doc/draft-stark-expect-ct/?include_text=1