### PR TITLE
Feature/report sample keyword

### DIFF
--- a/docs/supplements/friendly_directives_and_sources.md
+++ b/docs/supplements/friendly_directives_and_sources.md
@@ -1,0 +1,35 @@
+## Description
+Friendly directives and sources are included as shorthands for some of the CSP directive and source keyword values. For example, it is possible to omit `-src` from most directives, and the surrounding single quotes from most source keywords.
+
+The full array translation is below:
+
+
+### Directives
+```php
+array(
+    'default'   =>  'default-src',
+    'script'    =>  'script-src',
+    'style'     =>  'style-src',
+    'image'     =>  'img-src',
+    'img'       =>  'img-src',
+    'font'      =>  'font-src',
+    'child'     =>  'child-src',
+    'base'      =>  'base-uri',
+    'connect'   =>  'connect-src',
+    'form'      =>  'form-action',
+    'object'    =>  'object-src',
+    'report'    =>  'report-uri',
+    'reporting' =>  'report-uri'
+);
+```
+### Sources
+```php
+array(
+    'self'              => "'self'",
+    'none'              => "'none'",
+    'unsafe-inline'     => "'unsafe-inline'",
+    'unsafe-eval'       => "'unsafe-eval'",
+    'strict-dynamic'    => "'strict-dynamic'",
+    'report-sample'     =>  "'report-sample'",
+);
+```

--- a/docs/v2/friendly_directives_and_sources.md
+++ b/docs/v2/friendly_directives_and_sources.md
@@ -1,0 +1,35 @@
+## Description
+Friendly directives and sources are included as shorthands for some of the CSP directive and source keyword values. For example, it is possible to omit `-src` from most directives, and the surrounding single quotes from most source keywords.
+
+The full array translation is below:
+
+
+### Directives
+```php
+array(
+    'default'   =>  'default-src',
+    'script'    =>  'script-src',
+    'style'     =>  'style-src',
+    'image'     =>  'img-src',
+    'img'       =>  'img-src',
+    'font'      =>  'font-src',
+    'child'     =>  'child-src',
+    'base'      =>  'base-uri',
+    'connect'   =>  'connect-src',
+    'form'      =>  'form-action',
+    'object'    =>  'object-src',
+    'report'    =>  'report-uri',
+    'reporting' =>  'report-uri'
+);
+```
+### Sources
+```php
+array(
+    'self'              => "'self'",
+    'none'              => "'none'",
+    'unsafe-inline'     => "'unsafe-inline'",
+    'unsafe-eval'       => "'unsafe-eval'",
+    'strict-dynamic'    => "'strict-dynamic'",
+    'report-sample'     =>  "'report-sample'",
+);
+```

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -161,7 +161,8 @@ class SecureHeaders
         'none'              =>  "'none'",
         'unsafe-inline'     =>  "'unsafe-inline'",
         'unsafe-eval'       =>  "'unsafe-eval'",
-        'strict-dynamic'    =>  "'strict-dynamic'"
+        'strict-dynamic'    =>  "'strict-dynamic'",
+        'report-sample'     =>  "'report-sample'",
     ];
 
     protected $csproBlacklist       = [


### PR DESCRIPTION
Should be noted this is not adding support for the keyword (it
was always supported – keywords are not restricted. Rather, it
implements a shorthand (without the single quotes) to be used.

Info: https://www.chromestatus.com/feature/5792234276388864
Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Sources

Add documentation for friendly names and sources.