### PR TITLE
fix string containing zero being classed as "empty"

### DIFF
--- a/src/Headers/AbstractHeader.php
+++ b/src/Headers/AbstractHeader.php
@@ -175,7 +175,7 @@ abstract class AbstractHeader implements Header
      */
     public function __toString()
     {
-        return $this->name . ':' .(empty($this->value) ? '' : ' ' . $this->value);
+        return $this->name . ':' .($this->value === '' ? '' : ' ' . $this->value);
     }
 
     /**

--- a/tests/Headers/RegularHeaderTest.php
+++ b/tests/Headers/RegularHeaderTest.php
@@ -120,4 +120,11 @@ class RegularHeaderTest extends PHPUnit_Framework_TestCase
             (string) $Header
         );
     }
+
+    public function testNumericHeaderValueNotLost()
+    {
+        $Header = new RegularHeader('X-XSS-Protection', '0');
+
+        $this->assertSame('X-XSS-Protection: 0', (string) $Header);
+    }
 }


### PR DESCRIPTION
Because `true === (false == '0')`