### PR TITLE
Better PSR7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "psr/http-message": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -39,13 +40,11 @@
         }
     ],
     "suggest": {
-        "psr/http-message": "In case you want to use the PSR-7 adapter",
         "aidantwoods/markdownphpdocs": "Install this on its own and add it to your path, to auto-generate documentation if contributing to this repo."
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "dev-feature/braces/position_after_return_type_hint",
         "phpunit/phpunit": "^4.0",
-        "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.0"
     },
     "autoload-dev": {

--- a/src/Http/SecueHeadersHandler.php
+++ b/src/Http/SecueHeadersHandler.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Aidantwoods\SecureHeaders\Http;
+
+use Aidantwoods\SecureHeaders\Http\Psr7Adapter;
+use Aidantwoods\SecureHeaders\SecureHeaders;
+use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ * Secure headers handler
+ *
+ * Middleware to apply Secure headers to a PSR7 response
+ */
+class SecureHeadersHandler
+{
+    /**
+     * Headers
+     *
+     * @var SecureHeaders
+     *
+     * @access protected
+     */
+    protected $headers;
+
+    /**
+     * __construct
+     *
+     * @param SecureHeaders $headers Configured headers instance
+     *
+     * @access public
+     */
+    public function __construct(SecureHeaders $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * Handle PSR7 Request
+     *
+     * Delegates to middleware chain and applies secure headers to the returned
+     * response object before returning it
+     *
+     * @param Request  $request  Incoming PSR7 request
+     * @param Response $response PSR7 Response
+     * @param callable $next     Delagate middleware
+     *
+     * @return Response
+     *
+     * @access public
+     */
+    public function __invoke(Request $request, Response $response, callable $next)
+    {
+        $response = $next($request, $response);
+        $headers  = $this->headers;
+        $adapter  = $this->adapt($response);
+
+        $headers->apply($adapter);
+        $response = $adapter->getFinalResponse();
+
+        return $response;
+    }
+
+    /**
+     * Adapt a PSR7 Response
+     *
+     * @param Response $response PSR7 Response
+     *
+     * @return Psr7Adapter;
+     *
+     * @access protected
+     */
+    protected function adapt(Response $response)
+    {
+        return new Psr7Adapter($response);
+    }
+}


### PR DESCRIPTION
## Require `psr/http-message`
The `Psr7Adapter` *already* uses psr/http-message. Therefore either:
- This package *should* require the interface package (and thereby have a version constraint)
- **or** The adapter should be moved to  'bridge' package which requires it

## Add Middleware
This also adds a `SecureHeadersHandler` middleware object, which I'm *assuming* is how this is supposed to be used. It is the "old-style" middleware (takes request, response and next callable in invoke) because psr-15 is not stable yet. 
