### PR TITLE
Support PHPUnit version 5 and 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "dev-feature/braces/position_after_return_type_hint",
-        "phpunit/phpunit": "^4.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.0"
     },

--- a/tests/CSPTest.php
+++ b/tests/CSPTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\Http\StringHttpAdapter;
 use Aidantwoods\SecureHeaders\SecureHeaders;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CSPTest extends PHPUnit_Framework_TestCase
+class CSPTest extends TestCase
 {
     public function testStrictDynamicInjectableForNonInternalPolicy()
     {

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\Http\StringHttpAdapter;
 use Aidantwoods\SecureHeaders\SecureHeaders;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CookieTest extends PHPUnit_Framework_TestCase
+class CookieTest extends TestCase
 {
     public function testCookieUpgrades()
     {

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -3,9 +3,9 @@
 namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\Error;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ErrorTest extends PHPUnit_Framework_TestCase
+class ErrorTest extends TestCase
 {
     public function testMessagePreserved()
     {

--- a/tests/HeaderBagTest.php
+++ b/tests/HeaderBagTest.php
@@ -3,9 +3,9 @@
 namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HeaderBagTest extends PHPUnit_Framework_TestCase
+class HeaderBagTest extends TestCase
 {
     public function testThatHeadersAreAvailableWhenPassingAnArrayOnInstantiation()
     {

--- a/tests/HeaderFactoryTest.php
+++ b/tests/HeaderFactoryTest.php
@@ -3,9 +3,9 @@
 namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\HeaderFactory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HeaderFactoryTest extends PHPUnit_Framework_TestCase
+class HeaderFactoryTest extends TestCase
 {
     public function provideCSPHeaders()
     {

--- a/tests/Headers/CSPHeaderTest.php
+++ b/tests/Headers/CSPHeaderTest.php
@@ -3,9 +3,9 @@
 namespace Aidantwoods\SecureHeaders\Tests\Headers;
 
 use Aidantwoods\SecureHeaders\Headers\CSPHeader;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CSPHeaderTest extends PHPUnit_Framework_TestCase
+class CSPHeaderTest extends TestCase
 {
     public function testInjectFlag()
     {

--- a/tests/Headers/RegularHeaderTest.php
+++ b/tests/Headers/RegularHeaderTest.php
@@ -3,9 +3,9 @@
 namespace Aidantwoods\SecureHeaders\Tests\Headers;
 
 use Aidantwoods\SecureHeaders\Headers\RegularHeader;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RegularHeaderTest extends PHPUnit_Framework_TestCase
+class RegularHeaderTest extends TestCase
 {
     public function testInjectFlag()
     {

--- a/tests/Http/Psr7AdapterTest.php
+++ b/tests/Http/Psr7AdapterTest.php
@@ -4,10 +4,10 @@ namespace Aidantwoods\SecureHeaders\Tests\Http;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Http\Psr7Adapter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\Response;
 
-class Psr7AdapterTest extends PHPUnit_Framework_TestCase
+class Psr7AdapterTest extends TestCase
 {
     public function testProperlyFillsHeaderBag()
     {

--- a/tests/Http/StringHttpAdapterTest.php
+++ b/tests/Http/StringHttpAdapterTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Http;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Http\StringHttpAdapter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class StringHttpAdapterTest extends PHPUnit_Framework_TestCase
+class StringHttpAdapterTest extends TestCase
 {
     protected static $sampleHeaders = [
         'Content-Type: text/html',

--- a/tests/Operations/AddHeaderTest.php
+++ b/tests/Operations/AddHeaderTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\AddHeader;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AddHeaderTest extends PHPUnit_Framework_TestCase
+class AddHeaderTest extends TestCase
 {
     public function testHeadersCanBeAdded()
     {

--- a/tests/Operations/ApplySafeModeTest.php
+++ b/tests/Operations/ApplySafeModeTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\ApplySafeMode;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ApplySafeModeTest extends PHPUnit_Framework_TestCase
+class ApplySafeModeTest extends TestCase
 {
     public function testSTSMaxAgeWillBeReducedToOneDay()
     {

--- a/tests/Operations/CompileCSPTest.php
+++ b/tests/Operations/CompileCSPTest.php
@@ -5,9 +5,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\SecureHeaders;
 use Aidantwoods\SecureHeaders\Operations\CompileCSP;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CSPTest extends PHPUnit_Framework_TestCase
+class CSPTest extends TestCase
 {
     public function testStrictDynamicInjectableForNonInternalPolicy()
     {

--- a/tests/Operations/CompileExpectCTTest.php
+++ b/tests/Operations/CompileExpectCTTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\CompileExpectCT;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CompileExpectCTTest extends PHPUnit_Framework_TestCase
+class CompileExpectCTTest extends TestCase
 {
     public function provideExpectCTTestCases()
     {

--- a/tests/Operations/CompileHPKPTest.php
+++ b/tests/Operations/CompileHPKPTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\CompileHPKP;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CompileHPKPTest extends PHPUnit_Framework_TestCase
+class CompileHPKPTest extends TestCase
 {
     public function provideHPKPTestCases()
     {

--- a/tests/Operations/CompileHSTSTest.php
+++ b/tests/Operations/CompileHSTSTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\CompileHSTS;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CompileHSTSTest extends PHPUnit_Framework_TestCase
+class CompileHSTSTest extends TestCase
 {
     public function provideHSTSTestCases()
     {

--- a/tests/Operations/InjectStrictDynamicTest.php
+++ b/tests/Operations/InjectStrictDynamicTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\InjectStrictDynamic;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class InjectStrictDynamicTest extends PHPUnit_Framework_TestCase
+class InjectStrictDynamicTest extends TestCase
 {
     private $algs = ['sha256', 'sha384', 'sha512'];
 

--- a/tests/Operations/ModifyCookiesTest.php
+++ b/tests/Operations/ModifyCookiesTest.php
@@ -5,9 +5,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 use Aidantwoods\SecureHeaders\Header;
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\ModifyCookies;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ModifyCookiesTest extends PHPUnit_Framework_TestCase
+class ModifyCookiesTest extends TestCase
 {
     public function testFlagsCanBeSetBasedOnFullyMatchingCookieName()
     {

--- a/tests/Operations/RemoveHeadersTest.php
+++ b/tests/Operations/RemoveHeadersTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\RemoveHeaders;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RemoveHeadersTest extends PHPUnit_Framework_TestCase
+class RemoveHeadersTest extends TestCase
 {
     public function testCorrectHeadersRemoved()
     {

--- a/tests/Operations/RemovieCookiesTest.php
+++ b/tests/Operations/RemovieCookiesTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests\Operations;
 
 use Aidantwoods\SecureHeaders\HeaderBag;
 use Aidantwoods\SecureHeaders\Operations\RemoveCookies;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RemoveCookiesTest extends PHPUnit_Framework_TestCase
+class RemoveCookiesTest extends TestCase
 {
     public function testCorrectCookiesRemoved()
     {

--- a/tests/SafeModeTest.php
+++ b/tests/SafeModeTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\Http\StringHttpAdapter;
 use Aidantwoods\SecureHeaders\SecureHeaders;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SafeModeTest extends PHPUnit_Framework_TestCase
+class SafeModeTest extends TestCase
 {
     private $assertions = [
         'Contains',

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\Http\StringHttpAdapter;
 use Aidantwoods\SecureHeaders\SecureHeaders;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SecureHeadersTest extends PHPUnit_Framework_TestCase
+class SecureHeadersTest extends TestCase
 {
     private $assertions = [
         'Contains',

--- a/tests/StrictModeHeadersTest.php
+++ b/tests/StrictModeHeadersTest.php
@@ -4,9 +4,9 @@ namespace Aidantwoods\SecureHeaders\Tests;
 
 use Aidantwoods\SecureHeaders\Http\StringHttpAdapter;
 use Aidantwoods\SecureHeaders\SecureHeaders;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class StrictModeHeadersTest extends PHPUnit_Framework_TestCase
+class StrictModeHeadersTest extends TestCase
 {
     private $assertions = [
         'Contains',

--- a/tests/Util/TypesTest.php
+++ b/tests/Util/TypesTest.php
@@ -3,10 +3,10 @@
 namespace Aidantwoods\SecureHeaders\Tests\Util;
 
 use Aidantwoods\SecureHeaders\Util\Types;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class TypesTest extends PHPUnit_Framework_TestCase
+class TypesTest extends TestCase
 {
     /**
      * @dataProvider validValues
@@ -42,11 +42,10 @@ class TypesTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider invalidValues
+     * @expectedException Aidantwoods\SecureHeaders\Util\TypeError
      */
     public function testInvalidStringsRaiseExceptions($type, $variable)
     {
-        $this->setExpectedException('Aidantwoods\SecureHeaders\Util\TypeError');
-
         Types::assert([
             $type => [$variable]
         ]);

--- a/tests/ValidatorDelegates/CSPBadFlagsTest.php
+++ b/tests/ValidatorDelegates/CSPBadFlagsTest.php
@@ -5,9 +5,9 @@ namespace Aidantwoods\SecureHeaders\Tests\ValidatorDelegates;
 use Aidantwoods\SecureHeaders\ValidatorDelegates\CSPBadFlags;
 use Aidantwoods\SecureHeaders\HeaderFactory;
 use Aidantwoods\SecureHeaders\Error;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CSPBadFlagsTest extends PHPUnit_Framework_TestCase
+class CSPBadFlagsTest extends TestCase
 {
     public function provideBadFlagTestCases()
     {

--- a/tests/ValidatorDelegates/CSPRODestinationTest.php
+++ b/tests/ValidatorDelegates/CSPRODestinationTest.php
@@ -5,9 +5,9 @@ namespace Aidantwoods\SecureHeaders\Tests\ValidatorDelegates;
 use Aidantwoods\SecureHeaders\ValidatorDelegates\CSPRODestination;
 use Aidantwoods\SecureHeaders\HeaderFactory;
 use Aidantwoods\SecureHeaders\Error;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CSPRODestinationTest extends PHPUnit_Framework_TestCase
+class CSPRODestinationTest extends TestCase
 {
     protected static $errorMsg =
         'Content Security Policy Report Only header was sent,

--- a/tests/ValidatorDelegates/CSPWildcardsTest.php
+++ b/tests/ValidatorDelegates/CSPWildcardsTest.php
@@ -5,9 +5,9 @@ namespace Aidantwoods\SecureHeaders\Tests\ValidatorDelegates;
 use Aidantwoods\SecureHeaders\ValidatorDelegates\CSPWildcards;
 use Aidantwoods\SecureHeaders\HeaderFactory;
 use Aidantwoods\SecureHeaders\Error;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CSPWildcardsTest extends PHPUnit_Framework_TestCase
+class CSPWildcardsTest extends TestCase
 {
     public function provideWildcardTestCases()
     {


### PR DESCRIPTION
I've added `PHPUnit` versions 5 and 6 support.

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support the `PHPUnit\Framework\TestCase` namespace.