### PR TITLE
Introduce Free2Wait monetization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "free2wait/composer-free2wait": "*"
     },
     "autoload": {
         "psr-4": {
@@ -55,5 +56,10 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "free2wait": {
+        "to": {
+            "paypal": "your.paypal.to.receive.payouts@example.com"
+        }
     }
 }


### PR DESCRIPTION
Please refer to https://github.com/Free2Wait/composer-free2wait .

In short: this PR proposes a way to monetize open-source development of your project.
The idea is similar to how free-to-play works in gamedev industry: "You are free to wait for the package download - but in case if time is money for you, please consider buying non-waiting access to the package - every cent goes to the package developer to incentive the open-source development."

According to packagist statistics of your package https://packagist.org/packages/aidantwoods/secureheaders , in theory it could have brought to you about 4034 (installs) * 0.03 (conversion installs-to-sale) * 5 (price of each non-waiting access per month) = $605.1 .

Please give me your feedback about the idea: what do you think? Are you interested? Do you have any suggestions? Concerns?

Would be glad to receive any feeedback. Thank you for attention.