### PR TITLE
don't ignore README.md on .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,5 +10,4 @@
 .php_cs.dist export-ignore
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore
-README.md export-ignore
 TODO.md export-ignore


### PR DESCRIPTION
while it is okay to ignore the docs folder with all the detailed information, I think a README file is a bit too essential to exclude.

see https://github.com/aidantwoods/SecureHeaders/commit/7c64bd4fe4c3a4a3cfbf3cae712489f2cce5de8d#r32537766